### PR TITLE
Add installation instructions for Python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Requirements:
  - Pip
  - mysql (optional)
 
+Installing python2 and pip
+```bash
+    sudo apt-get install python2 python2-dev
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+    sudo python2 get-pip.py
+```
+
 Begin by creating a virtual-env
 ```
     pip install virtualenv


### PR DESCRIPTION
The main purpose to add this was to add `python2-dev` since without its installation `make install` doesn't work. 

![image](https://user-images.githubusercontent.com/18597330/129422457-7097ad71-d84f-40da-ab69-77dfe31cfb82.png)
